### PR TITLE
room.capacityのスキーマ変更(ver.4)

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -2,6 +2,9 @@
 class Room < ApplicationRecord
   belongs_to :studio
 
+  validates :capacity, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :price, presence: true, numericality: { only_integer: true, greater_than: 0 }
+
   scope :displayed, -> { where(status: Room.statuses[:active]) }
   scope :by_studio, ->(studio_id) { where(studio_id: studio_id) if studio_id.present?}
 

--- a/db/migrate/20181119065718_change_capacity_on_rooms.rb
+++ b/db/migrate/20181119065718_change_capacity_on_rooms.rb
@@ -1,0 +1,8 @@
+class ChangeCapacityOnRooms < ActiveRecord::Migration[5.0]
+  def up
+    change_column :rooms, :capacity, :integer, default: 0, null: false
+  end
+  def down
+    change_column :rooms, :capacity, :integer, default: 0
+  end
+end

--- a/db/migrate/20181119095010_change_no_null_columns_on_rooms.rb
+++ b/db/migrate/20181119095010_change_no_null_columns_on_rooms.rb
@@ -1,0 +1,22 @@
+class ChangeNoNullColumnsOnRooms < ActiveRecord::Migration[5.0]
+  def up
+    change_column :rooms, :price, :integer, default: 0, null: false
+    change_column :rooms, :speaker, :boolean, default: 0, null: false
+    change_column :rooms, :mixer, :boolean, default: 0, null: false
+    change_column :rooms, :cd, :boolean, default: 0, null: false
+    change_column :rooms, :md, :boolean, default: 0, null: false
+    change_column :rooms, :mp3, :boolean, default: 0, null: false
+    change_column :rooms, :dimmable, :boolean, default: 0, null: false
+    change_column :rooms, :wifi, :boolean, default: 0, null: false
+  end
+  def down
+    change_column :rooms, :price, :integer, default: 0
+    change_column :rooms, :speaker, :boolean, default: 0
+    change_column :rooms, :mixer, :boolean, default: 0
+    change_column :rooms, :cd, :boolean, default: 0
+    change_column :rooms, :md, :boolean, default: 0
+    change_column :rooms, :mp3, :boolean, default: 0
+    change_column :rooms, :dimmable, :boolean, default: 0
+    change_column :rooms, :wifi, :boolean, default: 0
+  end
+end

--- a/db/migrate/20181119095505_change_no_null_column_on_studios.rb
+++ b/db/migrate/20181119095505_change_no_null_column_on_studios.rb
@@ -1,0 +1,12 @@
+class ChangeNoNullColumnOnStudios < ActiveRecord::Migration[5.0]
+  def up
+    change_column :studios, :late_night, :boolean, default: 0, null: false
+    change_column :studios, :locker_room, :boolean, default: 0, null: false
+    change_column :studios, :parking, :boolean, default: 0, null: false
+  end
+  def down
+    change_column :studios, :late_night, :boolean, default: 0
+    change_column :studios, :locker_room, :boolean, default: 0
+    change_column :studios, :parking, :boolean, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,18 +32,18 @@ ActiveRecord::Schema.define(version: 20181114085207) do
     t.integer  "studio_id"
     t.string   "name"
     t.integer  "size"
-    t.integer  "capacity",                   default: 0
-    t.integer  "price",                      default: 0
+    t.integer  "capacity",                   default: 0,     null: false
+    t.integer  "price",                      default: 0,     null: false
     t.string   "mirror"
     t.integer  "floor"
-    t.boolean  "speaker",                    default: false
-    t.boolean  "mixer",                      default: false
-    t.boolean  "cd",                         default: false
-    t.boolean  "md",                         default: false
-    t.boolean  "mp3",                        default: false
+    t.boolean  "speaker",                    default: false, null: false
+    t.boolean  "mixer",                      default: false, null: false
+    t.boolean  "cd",                         default: false, null: false
+    t.boolean  "md",                         default: false, null: false
+    t.boolean  "mp3",                        default: false, null: false
     t.string   "other_source"
-    t.boolean  "dimmable",                   default: false
-    t.boolean  "wifi",                       default: false
+    t.boolean  "dimmable",                   default: false, null: false
+    t.boolean  "wifi",                       default: false, null: false
     t.string   "image"
     t.text     "feature",      limit: 65535
     t.text     "remarks",      limit: 65535
@@ -78,9 +78,9 @@ ActiveRecord::Schema.define(version: 20181114085207) do
     t.string   "tel"
     t.time     "start_hours"
     t.time     "end_hours"
-    t.boolean  "late_night",                          default: false
-    t.boolean  "locker_room",                         default: false
-    t.boolean  "parking",                             default: false
+    t.boolean  "late_night",                          default: false, null: false
+    t.boolean  "locker_room",                         default: false, null: false
+    t.boolean  "parking",                             default: false, null: false
     t.string   "cancell_deadline"
     t.string   "url"
     t.text     "feature",            limit: 65535


### PR DESCRIPTION
https://github.com/Vintom/studio-sagasu/issues/41 に対応。
room.capacityだけでなく、これまでnull:falseを設定できていなかったカラムにも再度null:falseとvalidationを適用。

【対象】
[rooms table]
:capacity
:price
:speaker
:mixer
:cd
:md
:mp3
:dimmable
:wifi

[sutdios table]
:late_night
:locker_room
:parking