### PR TITLE
検索クエリの表示形式修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,11 @@ class ApplicationController < ActionController::Base
                      elsif params[:area].to_i > 0
                        Area.find(params[:area].to_i).slug
                      end
-    session[:people] = params[:people] if params[:people].present?
+    session[:people] = if params[:people].present? && !params[:people].include?("-")
+                         params[:people]
+                       else
+                         session[:people]
+                       end
   end
 
   def basic_auth

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,11 +14,9 @@ class ApplicationController < ActionController::Base
                      elsif params[:area].to_i > 0
                        Area.find(params[:area].to_i).slug
                      end
-    session[:people] = if params[:people].present? && !params[:people].include?("-")
-                         params[:people]
-                       else
-                         session[:people]
-                       end
+    if params[:people].present? && !params[:people].include?("-")
+      session[:people] = params[:people]
+    end
   end
 
   def basic_auth

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,7 @@ class ApplicationController < ActionController::Base
 
   def set_search_info
     session[:area] = params[:area] if params[:area].present?
-    if params[:people].present? && !params[:people].include?("-")
-      session[:people] = params[:people]
-    end
+    session[:people] = params[:people] if params[:people].present? && !params[:people].include?("-")
   end
 
   def basic_auth

--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -103,6 +103,6 @@ class StudiosController < ApplicationController
            else
              params[:area]
            end
-    redirect_to studios_path(area: area, people: view_context.people_range_format(params[:people]))
+    redirect_to studios_path(area: area, people: view_context.people_range_format(session[:people]))
   end
 end

--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -103,6 +103,6 @@ class StudiosController < ApplicationController
            else
              params[:area]
            end
-    redirect_to studios_path(area: area, people: params[:people])
+    redirect_to studios_path(area: area, people: view_context.people_range_format(params[:people]))
   end
 end

--- a/app/helpers/studios_helper.rb
+++ b/app/helpers/studios_helper.rb
@@ -13,17 +13,7 @@ module StudiosHelper
   end
 
   def people_range_format(people_range_id)
-    logger.info("people_range_id: #{people_range_id}")
     return '' if people_range_id.blank?
-    min = PeopleRange.find(people_range_id).min
-    max = PeopleRange.find(people_range_id).max
-
-    if people_range_id.to_i == Settings.people_range.all
-      ''
-    elsif max == PeopleRange.maximum(:max)
-      "#{min}-"
-    else
-      "#{min}-#{max}"
-    end
+    PeopleRange.find(people_range_id).search_query_str
   end
 end

--- a/app/helpers/studios_helper.rb
+++ b/app/helpers/studios_helper.rb
@@ -11,4 +11,19 @@ module StudiosHelper
       '×'
     end
   end
+
+  def people_range_format(people_range_id)
+    logger.info("people_range_id: #{people_range_id}")
+    return '' if people_range_id.blank?
+    min = PeopleRange.find(people_range_id).min
+    max = PeopleRange.find(people_range_id).max
+
+    if people_range_id.to_i == Settings.people_range.all
+      ''
+    elsif max == PeopleRange.maximum(:max)
+      "#{min}-"
+    else
+      "#{min}-#{max}"
+    end
+  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,2 +1,0 @@
-people_range:
-  all: 6

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,2 @@
+people_range:
+  all: 6

--- a/db/migrate/20181202084316_add_search_query_str_to_people_ranges.rb
+++ b/db/migrate/20181202084316_add_search_query_str_to_people_ranges.rb
@@ -1,5 +1,5 @@
 class AddSearchQueryStrToPeopleRanges < ActiveRecord::Migration[5.0]
   def change
-    add_column :people_ranges, :search_query_str, :string, null:false
+    add_column :people_ranges, :search_query_str, :string, null:false, after: :max
   end
 end

--- a/db/migrate/20181202084316_add_search_query_str_to_people_ranges.rb
+++ b/db/migrate/20181202084316_add_search_query_str_to_people_ranges.rb
@@ -1,0 +1,5 @@
+class AddSearchQueryStrToPeopleRanges < ActiveRecord::Migration[5.0]
+  def change
+    add_column :people_ranges, :search_query_str, :string, null:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,9 +32,9 @@ ActiveRecord::Schema.define(version: 20181202084316) do
     t.string   "name",             null: false
     t.integer  "min",              null: false
     t.integer  "max",              null: false
+    t.string   "search_query_str", null: false
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
-    t.string   "search_query_str", null: false
   end
 
   create_table "rooms", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181130051654) do
+ActiveRecord::Schema.define(version: 20181202084316) do
 
   create_table "accounts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name"
@@ -29,11 +29,12 @@ ActiveRecord::Schema.define(version: 20181130051654) do
   end
 
   create_table "people_ranges", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",       null: false
-    t.integer  "min",        null: false
-    t.integer  "max",        null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "name",             null: false
+    t.integer  "min",              null: false
+    t.integer  "max",              null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.string   "search_query_str", null: false
   end
 
   create_table "rooms", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/seeds/people_range.yml
+++ b/db/seeds/people_range.yml
@@ -5,8 +5,9 @@
     name: "~5人"
     min: 1
     max: 5
-    created_at: &2 2018-11-30 08:38:24.000000000 Z
-    updated_at: &4 2018-11-30 08:38:24.000000000 Z
+    search_query_str: 1-5
+    created_at: &3 2018-12-02 07:24:59.000000000 Z
+    updated_at: &5 2018-12-02 07:24:59.000000000 Z
   attributes: !ruby/object:ActiveRecord::AttributeSet
     attributes: !ruby/object:ActiveRecord::LazyAttributeHash
       delegate_hash:
@@ -26,7 +27,7 @@
         name: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: name
           value_before_type_cast: "~5人"
-          type: &8 !ruby/object:ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::MysqlString
+          type: &2 !ruby/object:ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::MysqlString
             precision: 
             scale: 
             limit: 255
@@ -44,32 +45,38 @@
           type: *1
           original_attribute: 
           value: 5
+        search_query_str: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: search_query_str
+          value_before_type_cast: 1-5
+          type: *2
+          original_attribute: 
+          value: 1-5
         created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: created_at
-          value_before_type_cast: *2
+          value_before_type_cast: *3
           type: &10 !ruby/marshalable:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
             :__v2__: []
-            []: &5 !ruby/object:ActiveRecord::Type::DateTime
+            []: &6 !ruby/object:ActiveRecord::Type::DateTime
               precision: 0
               scale: 
               limit: 
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &3 2018-11-30 08:38:24.000000000 Z
-            zone: &6 !ruby/object:ActiveSupport::TimeZone
+            utc: &4 2018-12-02 07:24:59.000000000 Z
+            zone: &7 !ruby/object:ActiveSupport::TimeZone
               name: Etc/UTC
-            time: *3
+            time: *4
         updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: updated_at
-          value_before_type_cast: *4
+          value_before_type_cast: *5
           type: &13 !ruby/marshalable:ActiveRecord::AttributeMethods::TimeZoneConversion::TimeZoneConverter
             :__v2__: []
-            []: *5
+            []: *6
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &7 2018-11-30 08:38:24.000000000 Z
-            zone: *6
-            time: *7
+            utc: &8 2018-12-02 07:24:59.000000000 Z
+            zone: *7
+            time: *8
   new_record: false
   active_record_yaml_version: 1
 - !ruby/object:PeopleRange
@@ -78,8 +85,9 @@
     name: 6~10人
     min: 6
     max: 10
-    created_at: &9 2018-11-30 08:40:03.000000000 Z
-    updated_at: &12 2018-11-30 08:40:03.000000000 Z
+    search_query_str: 6-10
+    created_at: &9 2018-12-02 07:24:59.000000000 Z
+    updated_at: &12 2018-12-02 07:24:59.000000000 Z
   attributes: !ruby/object:ActiveRecord::AttributeSet
     attributes: !ruby/object:ActiveRecord::LazyAttributeHash
       delegate_hash:
@@ -92,7 +100,7 @@
         name: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: name
           value_before_type_cast: 6~10人
-          type: *8
+          type: *2
           original_attribute: 
           value: 6~10人
         min: !ruby/object:ActiveRecord::Attribute::FromDatabase
@@ -107,14 +115,20 @@
           type: *1
           original_attribute: 
           value: 10
+        search_query_str: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: search_query_str
+          value_before_type_cast: 6-10
+          type: *2
+          original_attribute: 
+          value: 6-10
         created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: created_at
           value_before_type_cast: *9
           type: *10
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &11 2018-11-30 08:40:03.000000000 Z
-            zone: *6
+            utc: &11 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *11
         updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: updated_at
@@ -122,8 +136,8 @@
           type: *13
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &14 2018-11-30 08:40:03.000000000 Z
-            zone: *6
+            utc: &14 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *14
   new_record: false
   active_record_yaml_version: 1
@@ -133,8 +147,9 @@
     name: 11~20人
     min: 11
     max: 20
-    created_at: &15 2018-11-30 08:41:45.000000000 Z
-    updated_at: &17 2018-11-30 08:41:45.000000000 Z
+    search_query_str: 11-20
+    created_at: &15 2018-12-02 07:24:59.000000000 Z
+    updated_at: &17 2018-12-02 07:24:59.000000000 Z
   attributes: !ruby/object:ActiveRecord::AttributeSet
     attributes: !ruby/object:ActiveRecord::LazyAttributeHash
       delegate_hash:
@@ -147,7 +162,7 @@
         name: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: name
           value_before_type_cast: 11~20人
-          type: *8
+          type: *2
           original_attribute: 
           value: 11~20人
         min: !ruby/object:ActiveRecord::Attribute::FromDatabase
@@ -162,14 +177,20 @@
           type: *1
           original_attribute: 
           value: 20
+        search_query_str: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: search_query_str
+          value_before_type_cast: 11-20
+          type: *2
+          original_attribute: 
+          value: 11-20
         created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: created_at
           value_before_type_cast: *15
           type: *10
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &16 2018-11-30 08:41:45.000000000 Z
-            zone: *6
+            utc: &16 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *16
         updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: updated_at
@@ -177,8 +198,8 @@
           type: *13
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &18 2018-11-30 08:41:45.000000000 Z
-            zone: *6
+            utc: &18 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *18
   new_record: false
   active_record_yaml_version: 1
@@ -188,8 +209,9 @@
     name: 21~30人
     min: 21
     max: 30
-    created_at: &19 2018-11-30 08:41:51.000000000 Z
-    updated_at: &21 2018-11-30 08:41:51.000000000 Z
+    search_query_str: 21-30
+    created_at: &19 2018-12-02 07:24:59.000000000 Z
+    updated_at: &21 2018-12-02 07:24:59.000000000 Z
   attributes: !ruby/object:ActiveRecord::AttributeSet
     attributes: !ruby/object:ActiveRecord::LazyAttributeHash
       delegate_hash:
@@ -202,7 +224,7 @@
         name: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: name
           value_before_type_cast: 21~30人
-          type: *8
+          type: *2
           original_attribute: 
           value: 21~30人
         min: !ruby/object:ActiveRecord::Attribute::FromDatabase
@@ -217,14 +239,20 @@
           type: *1
           original_attribute: 
           value: 30
+        search_query_str: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: search_query_str
+          value_before_type_cast: 21-30
+          type: *2
+          original_attribute: 
+          value: 21-30
         created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: created_at
           value_before_type_cast: *19
           type: *10
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &20 2018-11-30 08:41:51.000000000 Z
-            zone: *6
+            utc: &20 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *20
         updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: updated_at
@@ -232,8 +260,8 @@
           type: *13
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &22 2018-11-30 08:41:51.000000000 Z
-            zone: *6
+            utc: &22 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *22
   new_record: false
   active_record_yaml_version: 1
@@ -243,8 +271,9 @@
     name: 31人~
     min: 31
     max: 99999
-    created_at: &23 2018-11-30 08:42:16.000000000 Z
-    updated_at: &25 2018-11-30 08:42:16.000000000 Z
+    search_query_str: 31-
+    created_at: &23 2018-12-02 07:24:59.000000000 Z
+    updated_at: &25 2018-12-02 07:24:59.000000000 Z
   attributes: !ruby/object:ActiveRecord::AttributeSet
     attributes: !ruby/object:ActiveRecord::LazyAttributeHash
       delegate_hash:
@@ -257,7 +286,7 @@
         name: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: name
           value_before_type_cast: 31人~
-          type: *8
+          type: *2
           original_attribute: 
           value: 31人~
         min: !ruby/object:ActiveRecord::Attribute::FromDatabase
@@ -272,14 +301,20 @@
           type: *1
           original_attribute: 
           value: 99999
+        search_query_str: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: search_query_str
+          value_before_type_cast: 31-
+          type: *2
+          original_attribute: 
+          value: 31-
         created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: created_at
           value_before_type_cast: *23
           type: *10
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &24 2018-11-30 08:42:16.000000000 Z
-            zone: *6
+            utc: &24 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *24
         updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: updated_at
@@ -287,8 +322,8 @@
           type: *13
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &26 2018-11-30 08:42:16.000000000 Z
-            zone: *6
+            utc: &26 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *26
   new_record: false
   active_record_yaml_version: 1
@@ -298,8 +333,9 @@
     name: 指定しない
     min: 1
     max: 99999
-    created_at: &27 2018-11-30 08:42:40.000000000 Z
-    updated_at: &29 2018-11-30 08:42:40.000000000 Z
+    search_query_str: ''
+    created_at: &27 2018-12-02 07:24:59.000000000 Z
+    updated_at: &29 2018-12-02 07:24:59.000000000 Z
   attributes: !ruby/object:ActiveRecord::AttributeSet
     attributes: !ruby/object:ActiveRecord::LazyAttributeHash
       delegate_hash:
@@ -312,7 +348,7 @@
         name: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: name
           value_before_type_cast: 指定しない
-          type: *8
+          type: *2
           original_attribute: 
           value: 指定しない
         min: !ruby/object:ActiveRecord::Attribute::FromDatabase
@@ -327,14 +363,20 @@
           type: *1
           original_attribute: 
           value: 99999
+        search_query_str: !ruby/object:ActiveRecord::Attribute::FromDatabase
+          name: search_query_str
+          value_before_type_cast: ''
+          type: *2
+          original_attribute: 
+          value: ''
         created_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: created_at
           value_before_type_cast: *27
           type: *10
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &28 2018-11-30 08:42:40.000000000 Z
-            zone: *6
+            utc: &28 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *28
         updated_at: !ruby/object:ActiveRecord::Attribute::FromDatabase
           name: updated_at
@@ -342,8 +384,8 @@
           type: *13
           original_attribute: 
           value: !ruby/object:ActiveSupport::TimeWithZone
-            utc: &30 2018-11-30 08:42:40.000000000 Z
-            zone: *6
+            utc: &30 2018-12-02 07:24:59.000000000 Z
+            zone: *7
             time: *30
   new_record: false
   active_record_yaml_version: 1


### PR DESCRIPTION
# 変更内容
* [x] 検索クエリが`people_ranges.id`ではなく、既存のままに戻す(ex.`1-5`, `31-`)
* [ ] 人数で検索時に、ヘッダーに検索履歴が残るようにする 