### PR TITLE
ヘッダーにエリアの検索履歴が残るようにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,11 +9,9 @@ class ApplicationController < ActionController::Base
   private
 
   def set_search_info
-    session[:area] = if params[:area].present? && params[:area].to_i == 0
-                       params[:area]
-                     elsif params[:area].to_i > 0
-                       Area.find(params[:area].to_i).slug
-                     end
+    if params[:area].present? && params[:area].to_i == 0
+      session[:area] = params[:area]
+    end
     if params[:people].present? && !params[:people].include?("-")
       session[:people] = params[:people]
     end


### PR DESCRIPTION
https://github.com/Vintom/studio-sagasu/issues/54 に対応。
エリアを絞って検索（「新宿・代々木」など）後、検索窓で「人数」のみ変更した際に、エリアの選択欄がデフォルト（「エリア」）に戻ってしまう事象を修正します。