### PR TITLE
#87_phase2 mailerにエリアとルーム数追加

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -11,7 +11,7 @@ class ReportMailer < ApplicationMailer
     @prefectures = Area.order(:id).group(:prefecture).pluck(:prefecture)
     mail(
       subject: "sagasu.spaceスタジオ数週次レポート",
-      to: "all@vintom.co.jp"
+      to: "all@vintom.co.jp, shikami@someya-gumi.org, someya@someya-gumi.org"
     ) do |format|
       format.html
     end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -2,9 +2,16 @@ class ReportMailer < ApplicationMailer
   default from: "noreply@vintom.co.jp"
 
   def send_studios_report
-    @active_studio = Studio.where(status: 1)
-    @inactive_studio = Studio.where(status: 0)
-    @reviewing_studio = Studio.where(status: 2)
+    @area_studios = Studio.includes(:area)
+    @studio_rooms = Room.includes(:studio)
+    @area_studio_rooms = Room.includes(studio: :area)
+    @prefectures = Area.order(:id).group(:prefecture).pluck(:prefecture)
+    @active_studios = Studio.where(status: 1)
+    @inactive_studios = Studio.where(status: 0)
+    @reviewing_studios = Studio.where(status: 2)
+    @active_rooms = Room.where(status: 1)
+    @inactive_rooms = Room.where(status: 0)
+    @reviewing_rooms = Room.where(status: 2)
     mail(
       subject: "sagasu.spaceスタジオ数週次レポート",
       to: "all@vintom.co.jp"

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,5 +1,6 @@
 class ReportMailer < ApplicationMailer
   default from: "noreply@vintom.co.jp"
+  STATUS_NUMBER = [1,0,2]
 
   def send_studios_report
     @studios = Studio.all

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -9,7 +9,7 @@ class ReportMailer < ApplicationMailer
       subject: "sagasu.spaceスタジオ数週次レポート",
       to: "all@vintom.co.jp"
     ) do |format|
-      format.text
+      format.html
     end
   end
 end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -2,16 +2,12 @@ class ReportMailer < ApplicationMailer
   default from: "noreply@vintom.co.jp"
 
   def send_studios_report
+    @studios = Studio.all
+    @rooms = Room.all
     @area_studios = Studio.includes(:area)
     @studio_rooms = Room.includes(:studio)
     @area_studio_rooms = Room.includes(studio: :area)
     @prefectures = Area.order(:id).group(:prefecture).pluck(:prefecture)
-    @active_studios = Studio.where(status: 1)
-    @inactive_studios = Studio.where(status: 0)
-    @reviewing_studios = Studio.where(status: 2)
-    @active_rooms = Room.where(status: 1)
-    @inactive_rooms = Room.where(status: 0)
-    @reviewing_rooms = Room.where(status: 2)
     mail(
       subject: "sagasu.spaceスタジオ数週次レポート",
       to: "all@vintom.co.jp"

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,6 +1,6 @@
 class ReportMailer < ApplicationMailer
   default from: "noreply@vintom.co.jp"
-  STATUS_NUMBER = [1,0,2]
+  STATUS_ORDER = [1,0,2]
 
   def send_studios_report
     @studios = Studio.all

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -7,6 +7,7 @@ class Room < ApplicationRecord
 
   scope :displayed, -> { where(status: Room.statuses[:active]) }
   scope :by_studio, ->(studio_id) { where(studio_id: studio_id) if studio_id.present?}
+  scope :by_status, ->(status) { where(status: status)}
 
   enum status: { inactive: 0, active: 1 }
   enum floor: { 'フローリング': 1, 'リノリウム': 2, 'その他': 99 }

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -9,6 +9,6 @@ class Room < ApplicationRecord
   scope :by_studio, ->(studio_id) { where(studio_id: studio_id) if studio_id.present?}
   scope :by_status, ->(status) { where(status: status)}
 
-  enum status: { inactive: 0, active: 1 }
+  enum status: { inactive: 0, active: 1, reviewing: 2 }
   enum floor: { 'フローリング': 1, 'リノリウム': 2, 'その他': 99 }
 end

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -22,8 +22,9 @@ class Studio < ApplicationRecord
     ids = joins(:rooms).group(:id).order('count_studios_id desc').count('studios.id').keys
     Studio.where(id: ids).order(['field(id, ?)', ids])
   }
+  scope :by_status, ->(status) { where(status: status)}
 
-  enum status: { inactive: 0, active: 1 }
+  enum status: { inactive: 0, active: 1, reviewing: 2 }
   validates :slug, uniqueness: true
 
   def max_capacity

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -6,37 +6,39 @@
   <body>
     <h1>sagasu.space登録スタジオ数</h1>
     <p>現在の登録スタジオ数をお知らせします。</p>
-    <table>
-      <caption>Active</caption>
-      <tr>
-        <th>都道府県</th>
-        <th>エリア</th>
-        <th>スタジオ数</th>
-        <th>ルーム数</th>
-      </tr>
-      <tr>
-        <th>合計</th>
-        <th>-</th>
-        <th><%= @active_studios.count %></th>
-        <th><%= @active_rooms.count %></th>
-      </tr>
-      <% @prefectures.each do |p| %>
-        <tr>
-          <td><%= p %></td>
-          <td>合計</td>
-          <td><%= @area_studios.where(areas: {prefecture: p}).count %></td>
-          <td><%= @area_studio_rooms.where(status: 1).where(areas: {prefecture: p}).count %></td>
-        </tr>
-        <% Area.where(prefecture: p).each do |a| %>
+    <% [1,0,2].each do |n| %>
+      <table>
+        <caption><%= Studio.statuses.key(n) %></caption>
           <tr>
-            <td><%= p %></td>
-            <td><%= a.city %></td>
-            <td><%= @active_studios.where(area_id: a.id).count %></td>
-            <td><%= @studio_rooms.where(status: 1).where(studios: {area_id: a.id}).count %></td>
+            <th>都道府県</th>
+            <th>エリア</th>
+            <th>スタジオ数</th>
+            <th>ルーム数</th>
           </tr>
-        <% end %>
-      <% end %>
-    </table>
+          <tr>
+            <th>合計</th>
+            <th>-</th>
+            <th><%= @studios.by_status(n).count %></th>
+            <th><%= @rooms.by_status(n).count %></th>
+          </tr>
+          <% @prefectures.each do |p| %>
+            <tr>
+              <td><%= p %></td>
+              <td>合計</td>
+              <td><%= @area_studios.by_status(n).where(areas: {prefecture: p}).count %></td>
+              <td><%= @area_studio_rooms.by_status(n).where(areas: {prefecture: p}).count %></td>
+            </tr>
+            <% Area.where(prefecture: p).each do |a| %>
+              <tr>
+                <td><%= p %></td>
+                <td><%= a.city %></td>
+                <td><%= @studios.by_status(n).where(area_id: a.id).count %></td>
+                <td><%= @studio_rooms.by_status(n).where(studios: {area_id: a.id}).count %></td>
+              </tr>
+            <% end %>
+          <% end %>
+      </table>
+    <% end %>
 
     <p>今週もお疲れ様でした！</p>
   </body>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>sagasu.space登録スタジオ数</h1>
+    <p>現在の登録スタジオ数をお知らせします。</p>
+    <p>active: <%= @active_studio.count %></p>
+    <p>inactive: <%= @inactive_studio.count %></p>
+    <p>reviewing: <%= @reviewing_studio.count %></p>
+    <p>今週もお疲れ様でした！</p>
+  </body>
+</html>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -6,9 +6,9 @@
   <body>
     <h1>sagasu.space登録スタジオ数</h1>
     <p>現在の登録スタジオ数をお知らせします。</p>
-    <% ReportMailer::STATUS_NUMBER.each do |n| %>
+    <% ReportMailer::STATUS_ORDER.each do |status| %>
       <table style="border: 3px solid; border-collapse: collapse; max-width: 100%; text-align: left; margin-bottom: 1.5rem;">
-        <caption style="font-size: 1.5rem; font-weight: bold;"><%= Studio.statuses.key(n) %></caption>
+        <caption style="font-size: 1.5rem; font-weight: bold;"><%= Studio.statuses.key(status) %></caption>
           <tr style="border: 3px solid; border-collapse: collapse;">
             <th>都道府県</th>
             <th>エリア</th>
@@ -18,22 +18,22 @@
           <tr style="border: 3px solid; border-collapse: collapse; font-weight: bold;">
             <td>合計</td>
             <td>-</td>
-            <td><%= @studios.by_status(n).count %></td>
-            <td><%= @rooms.by_status(n).count %></td>
+            <td><%= @studios.by_status(status).count %></td>
+            <td><%= @rooms.by_status(status).count %></td>
           </tr>
           <% @prefectures.each do |p| %>
             <tr style="border: 1px solid; border-collapse: collapse; font-weight: bold;">
               <td><%= p %></td>
               <td>合計</td>
-              <td><%= @area_studios.by_status(n).where(areas: {prefecture: p}).count %></td>
-              <td><%= @area_studio_rooms.by_status(n).where(areas: {prefecture: p}).count %></td>
+              <td><%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %></td>
+              <td><%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count %></td>
             </tr>
             <% Area.where(prefecture: p).each do |a| %>
               <tr>
                 <td><%= p %></td>
                 <td><%= a.city %></td>
-                <td><%= @studios.by_status(n).where(area_id: a.id).count %></td>
-                <td><%= @studio_rooms.by_status(n).where(studios: {area_id: a.id}).count %></td>
+                <td><%= @studios.by_status(status).where(area_id: a.id).count %></td>
+                <td><%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count %></td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -7,22 +7,22 @@
     <h1>sagasu.space登録スタジオ数</h1>
     <p>現在の登録スタジオ数をお知らせします。</p>
     <% [1,0,2].each do |n| %>
-      <table>
-        <caption><%= Studio.statuses.key(n) %></caption>
-          <tr>
+      <table style="border: 3px solid; border-collapse: collapse; max-width: 100%; text-align: left; margin-bottom: 1.5rem;">
+        <caption style="font-size: 1.5rem; font-weight: bold;"><%= Studio.statuses.key(n) %></caption>
+          <tr style="border: 3px solid; border-collapse: collapse;">
             <th>都道府県</th>
             <th>エリア</th>
             <th>スタジオ数</th>
             <th>ルーム数</th>
           </tr>
-          <tr>
+          <tr style="border: 3px solid; border-collapse: collapse; font-weight: bold;">
             <td>合計</td>
             <td>-</td>
             <td><%= @studios.by_status(n).count %></td>
             <td><%= @rooms.by_status(n).count %></td>
           </tr>
           <% @prefectures.each do |p| %>
-            <tr>
+            <tr style="border: 1px solid; border-collapse: collapse; font-weight: bold;">
               <td><%= p %></td>
               <td>合計</td>
               <td><%= @area_studios.by_status(n).where(areas: {prefecture: p}).count %></td>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -6,9 +6,38 @@
   <body>
     <h1>sagasu.space登録スタジオ数</h1>
     <p>現在の登録スタジオ数をお知らせします。</p>
-    <p>active: <%= @active_studio.count %></p>
-    <p>inactive: <%= @inactive_studio.count %></p>
-    <p>reviewing: <%= @reviewing_studio.count %></p>
+    <table>
+      <caption>Active</caption>
+      <tr>
+        <th>都道府県</th>
+        <th>エリア</th>
+        <th>スタジオ数</th>
+        <th>ルーム数</th>
+      </tr>
+      <tr>
+        <th>合計</th>
+        <th>-</th>
+        <th><%= @active_studios.count %></th>
+        <th><%= @active_rooms.count %></th>
+      </tr>
+      <% @prefectures.each do |p| %>
+        <tr>
+          <td><%= p %></td>
+          <td>合計</td>
+          <td><%= @area_studios.where(areas: {prefecture: p}).count %></td>
+          <td><%= @area_studio_rooms.where(status: 1).where(areas: {prefecture: p}).count %></td>
+        </tr>
+        <% Area.where(prefecture: p).each do |a| %>
+          <tr>
+            <td><%= p %></td>
+            <td><%= a.city %></td>
+            <td><%= @active_studios.where(area_id: a.id).count %></td>
+            <td><%= @studio_rooms.where(status: 1).where(studios: {area_id: a.id}).count %></td>
+          </tr>
+        <% end %>
+      <% end %>
+    </table>
+
     <p>今週もお疲れ様でした！</p>
   </body>
 </html>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -6,7 +6,7 @@
   <body>
     <h1>sagasu.space登録スタジオ数</h1>
     <p>現在の登録スタジオ数をお知らせします。</p>
-    <% [1,0,2].each do |n| %>
+    <% ReportMailer::STATUS_NUMBER.each do |n| %>
       <table style="border: 3px solid; border-collapse: collapse; max-width: 100%; text-align: left; margin-bottom: 1.5rem;">
         <caption style="font-size: 1.5rem; font-weight: bold;"><%= Studio.statuses.key(n) %></caption>
           <tr style="border: 3px solid; border-collapse: collapse;">

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -16,10 +16,10 @@
             <th>ルーム数</th>
           </tr>
           <tr>
-            <th>合計</th>
-            <th>-</th>
-            <th><%= @studios.by_status(n).count %></th>
-            <th><%= @rooms.by_status(n).count %></th>
+            <td>合計</td>
+            <td>-</td>
+            <td><%= @studios.by_status(n).count %></td>
+            <td><%= @rooms.by_status(n).count %></td>
           </tr>
           <% @prefectures.each do |p| %>
             <tr>

--- a/app/views/report_mailer/send_studios_report.text.erb
+++ b/app/views/report_mailer/send_studios_report.text.erb
@@ -1,7 +1,0 @@
-現在の登録スタジオ数をお知らせします。
-
-active: <%= @active_studio.count %>
-inactive: <%= @inactive_studio.count %>
-reviewing: <%= @reviewing_studio.count %>
-
-今週もお疲れ様でした！

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -10,6 +10,7 @@ if Rails.env.production?
     enable_starttls_auto: true
   }
 elsif Rails.env.development?
+  ActionMailer::Base.default_url_options = { host: 'localhost:3000' }
   ActionMailer::Base.delivery_method = :letter_opener
 else
   ActionMailer::Base.delivery_method = :test


### PR DESCRIPTION
# 関連issue
https://github.com/Vintom/studio-sagasu/issues/77
# 要件
* active/inactive/reviewingで分ける
* 都道府県ごとに分ける
* エリアで分ける
* ルーム数を追加
![Image from iOS (1)](https://user-images.githubusercontent.com/32565613/57304049-8621e480-7119-11e9-9b34-02b9086002e9.jpg)

# 作業工程
* [x] 要件定義
* [x] formatをtext→htmlにする
* [x] room数を引っ張ってくる
* [x] prefecture(都道府県)を引っ張ってくる
* [x] areaを引っ張ってくる
* [x] リファクタリング
* [x] テーブルにstyleを当てる
