### PR TITLE
#87_phase3 mailerに前週比スタジオ数/ルーム数増減,概況追加

### DIFF
--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -8,6 +8,7 @@ class Room < ApplicationRecord
   scope :displayed, -> { where(status: Room.statuses[:active]) }
   scope :by_studio, ->(studio_id) { where(studio_id: studio_id) if studio_id.present?}
   scope :by_status, ->(status) { where(status: status)}
+  scope :by_last_week_status, ->(last_week_status) { where(last_week_status: last_week_status)}
 
   enum status: { inactive: 0, active: 1, reviewing: 2 }
   enum floor: { 'フローリング': 1, 'リノリウム': 2, 'その他': 99 }

--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -23,6 +23,7 @@ class Studio < ApplicationRecord
     Studio.where(id: ids).order(['field(id, ?)', ids])
   }
   scope :by_status, ->(status) { where(status: status)}
+  scope :by_last_week_status, ->(last_week_status) { where(last_week_status: last_week_status)}
 
   enum status: { inactive: 0, active: 1, reviewing: 2 }
   validates :slug, uniqueness: true

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -4,13 +4,13 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <div>
-      <p><%= "・Activeなスタジオ数は#{@studios.by_status(1).count}です。先週から#{@studios.by_status(1).count - @studios.by_last_week_status(1).count}個増えました。" %><br>
+    <div style="margin-bottom: 3rem;">
+      <p><%= "・Activeなスタジオ数は#{@studios.by_status(1).count}です。先週からの増減は#{@studios.by_status(1).count - @studios.by_last_week_status(1).count}です。" %><br>
       <%= "・停止中(Inactive)のスタジオ数は#{@studios.by_status(0).count}個です。" %><br>
       <%= "・審査(Reviewing)が必要なスタジオ数は#{@studios.by_status(2).count}個です。" %></p>
     </div>
     <% ReportMailer::STATUS_ORDER.each do |status| %>
-      <table style="border-bottom: 1px solid; border-collapse: collapse; max-width: 100%; text-align: center; margin-bottom: 1.5rem;">
+      <table style="border-bottom: 1px solid; border-collapse: collapse; max-width: 100%; text-align: center; margin-top: 3rem;">
         <caption style="text-align: left; margin-bottom: 1.5rem;">
           <%= "#{Studio.statuses.key(status).capitalize}なスタジオは前週比で#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)}、ルームは#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)}の増減で、#{@studios.by_status(status).count}スタジオ、#{@rooms.by_status(status).count}ルームになりました。" %>
           <% if @studios.by_status(status).count > @studios.by_last_week_status(status).count %>
@@ -35,22 +35,22 @@
           内訳は以下のとおりです。
         </caption>
           <tr style="border-bottom: 1px solid; border-collapse: collapse;">
-            <th style="padding: 0 20px;">都道府県</th>
-            <th style="padding: 0 20px;">エリア</th>
-            <th style="padding: 0 20px;">Studio</th>
-            <th style="padding: 0 20px;">Room</th>
+            <th style="padding-right: 40px; text-align: left;">都道府県</th>
+            <th style="text-align: left;">エリア</th>
+            <th style="padding-left: 40px; text-align: right;">Studio</th>
+            <th style="padding-left: 40px; text-align: right;">Room</th>
           </tr>
           <tr style="border-bottom: 1px solid; border-collapse: collapse; font-weight: bold;">
             <td></td>
             <td></td>
-            <td>
+            <td style="text-align: right;">
               <% if @studios.by_status(status).count == @studios.by_last_week_status(status).count %>
                 <%= @studios.by_status(status).count %>
               <% else %>
                 <%= @studios.by_status(status).count %><small><%= "(#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)})" %></small>
               <% end %>
             </td>
-            <td>
+            <td style="text-align: right;">
               <% if @rooms.by_status(status).count == @rooms.by_last_week_status(status).count %>
                 <%= @rooms.by_status(status).count %>
               <% else %>
@@ -60,16 +60,16 @@
           </tr>
           <% @prefectures.each do |p| %>
             <tr style="border-top: 1px solid; border-collapse: collapse; font-weight: bold;">
-              <td><%= p %></td>
-              <td>合計</td>
-              <td>
+              <td style="text-align: left;"><%= p %></td>
+              <td style="text-align: left;">合計</td>
+              <td style="text-align: right;">
                 <% if @area_studios.by_status(status).where(areas: {prefecture: p}).count == @area_studios.by_last_week_status(status).where(areas: {prefecture: p}).count %>
                   <%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %>
                 <% else %>
                   <%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %><small><%= "(#{sprintf("%+d", @area_studios.by_status(status).where(areas: {prefecture: p}).count - @area_studios.by_last_week_status(status).where(areas: {prefecture: p}).count)})" %></small>
                 <% end %>
               </td>
-              <td>
+              <td style="text-align: right;">
                 <% if @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count == @area_studio_rooms.by_last_week_status(status).where(areas: {prefecture: p}).count %>
                   <%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count %>
                 <% else %>
@@ -80,15 +80,15 @@
             <% Area.where(prefecture: p).each do |a| %>
               <tr>
                 <td></td>
-                <td><%= a.city %></td>
-                <td>
+                <td style="text-align: left;"><%= a.city %></td>
+                <td style="text-align: right;">
                   <% if @studios.by_status(status).where(area_id: a.id).count == @studios.by_last_week_status(status).where(area_id: a.id).count %>
                     <%= @studios.by_status(status).where(area_id: a.id).count %>
                   <% else %>
                     <%= @studios.by_status(status).where(area_id: a.id).count %><small><%= "(#{sprintf("%+d", @studios.by_status(status).where(area_id: a.id).count - @studios.by_last_week_status(status).where(area_id: a.id).count)})" %></small>
                   <% end %>
                 </td>
-                <td>
+                <td style="text-align: right;">
                   <% if @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count == @studio_rooms.by_last_week_status(status).where(studios: {area_id: a.id}).count %>
                     <%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count %>
                   <% else %>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -11,7 +11,29 @@
     </div>
     <% ReportMailer::STATUS_ORDER.each do |status| %>
       <table style="border-bottom: 1px solid; border-collapse: collapse; max-width: 100%; text-align: center; margin-bottom: 1.5rem;">
-        <caption style="font-size: 1.5rem; font-weight: bold;"><%= Studio.statuses.key(status) %></caption>
+        <caption style="text-align: left; margin-bottom: 1.5rem;">
+          <%= "#{Studio.statuses.key(status).capitalize}なスタジオは前週比で#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)}、ルームは#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)}の増減で、#{@studios.by_status(status).count}スタジオ、#{@rooms.by_status(status).count}ルームになりました。" %>
+          <% if @studios.by_status(status).count > @studios.by_last_week_status(status).count %>
+            <% if status == 1 %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました！！ありがとうございます！！(^^)" %>a
+            <% else %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました。対応をお願いします。" %>
+            <% end %>
+          <% elsif @studios.by_status(status).count == @studios.by_last_week_status(status).count %>
+            <% if status == 1 %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数は変わりません。来週は増えるといいなあとよもさんが言ってました。" %>
+            <% else %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数は変わりません。" %>
+            <% end %>
+          <% else %>
+            <% if status == 1 %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオが減ってしまいました。悲しいですね(;_;)" %>
+            <% else %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオが減りました。ご対応ありがとうございます(^^)" %>
+            <% end %>
+          <% end %>
+          内訳は以下のとおりです。
+        </caption>
           <tr style="border-bottom: 1px solid; border-collapse: collapse;">
             <th style="padding: 0 20px;">都道府県</th>
             <th style="padding: 0 20px;">エリア</th>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -21,27 +21,27 @@
             <td>合計</td>
             <td>-</td>
             <td><%= @studios.by_status(status).count %></td>
-            <td>(あとで追加)</td>
+            <td><%= @studios.by_status(status).count - @studios.by_last_week_status(status).count %></td>
             <td><%= @rooms.by_status(status).count %></td>
-            <td>(あとで追加)</td>
+            <td><%= @rooms.by_status(status).count - @rooms.by_last_week_status(status).count %></td>
           </tr>
           <% @prefectures.each do |p| %>
             <tr style="border: 1px solid; border-collapse: collapse; font-weight: bold;">
               <td><%= p %></td>
               <td>合計</td>
               <td><%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %></td>
-              <td>(あとで追加)</td>
+              <td><%= @area_studios.by_status(status).where(areas: {prefecture: p}).count - @area_studios.by_last_week_status(status).where(areas: {prefecture: p}).count %></td>
               <td><%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count %></td>
-              <td>(あとで追加)</td>
+              <td><%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count - @area_studio_rooms.by_last_week_status(status).where(areas: {prefecture: p}).count %></td>
             </tr>
             <% Area.where(prefecture: p).each do |a| %>
               <tr>
                 <td><%= p %></td>
                 <td><%= a.city %></td>
                 <td><%= @studios.by_status(status).where(area_id: a.id).count %></td>
-                <td>(あとで追加)</td>
+                <td><%= @studios.by_status(status).where(area_id: a.id).count - @studios.by_last_week_status(status).where(area_id: a.id).count %></td>
                 <td><%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count %></td>
-                <td>(あとで追加)</td>
+                <td><%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count - @studio_rooms.by_last_week_status(status).where(studios: {area_id: a.id}).count %></td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -12,7 +12,7 @@
     <% ReportMailer::STATUS_ORDER.each do |status| %>
       <table style="border-bottom: 1px solid; border-collapse: collapse; max-width: 100%; text-align: center; margin-top: 3rem;">
         <caption style="text-align: left; margin-bottom: 1.5rem;">
-          <%= "#{Studio.statuses.key(status).capitalize}なスタジオは前週比で#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)}、ルームは#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)}の増減で、#{@studios.by_status(status).count}スタジオ、#{@rooms.by_status(status).count}ルームになりました。" %>
+          <%= "#{Studio.statuses.key(status).capitalize}なスタジオは前週比で#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)}、ルームは#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)}の増減で、#{@studios.by_status(status).count}スタジオ、#{@rooms.by_status(status).count}ルームになりました。" %><br>
           <% if @studios.by_status(status).count > @studios.by_last_week_status(status).count %>
             <% if status == 1 %>
               <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました！！ありがとうございます！！(^^)" %>a
@@ -32,7 +32,7 @@
               <%= "#{Studio.statuses.key(status).capitalize}なスタジオが減りました。ご対応ありがとうございます(^^)" %>
             <% end %>
           <% end %>
-          内訳は以下のとおりです。
+          <br>内訳は以下のとおりです。
         </caption>
           <tr style="border-bottom: 1px solid; border-collapse: collapse;">
             <th style="padding-right: 40px; text-align: left;">都道府県</th>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -15,7 +15,7 @@
           <%= "#{Studio.statuses.key(status).capitalize}なスタジオは前週比で#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)}、ルームは#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)}の増減で、#{@studios.by_status(status).count}スタジオ、#{@rooms.by_status(status).count}ルームになりました。" %><br>
           <% if @studios.by_status(status).count > @studios.by_last_week_status(status).count %>
             <% if status == 1 %>
-              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました！！ありがとうございます！！(^^)" %>a
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました！！ありがとうございます！！(^^)" %>
             <% else %>
               <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました。対応をお願いします。" %>
             <% end %>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -5,6 +5,11 @@
   </head>
   <body>
     <h1>sagasu.space登録スタジオ数</h1>
+    <div style="border: 2px solid;">
+      <p><%= "・アクティブなスタジオ数は先週から#{@studios.by_status(1).count - @studios.by_last_week_status(1).count}個増えました。" %><br>
+      <%= "・停止中のスタジオ数は#{@studios.by_status(0).count}個です。" %><br>
+      <%= "・審査が必要なスタジオ数は#{@studios.by_status(2).count}個です。" %></p>
+    </div>
     <p>現在の登録スタジオ数をお知らせします。</p>
     <% ReportMailer::STATUS_ORDER.each do |status| %>
       <table style="border: 3px solid; border-collapse: collapse; max-width: 100%; text-align: left; margin-bottom: 1.5rem;">

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -34,6 +34,7 @@
               <% else %>
                 <%= @rooms.by_status(status).count %><small><%= "(#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)})" %></small>
               <% end %>
+            </td>
           </tr>
           <% @prefectures.each do |p| %>
             <tr style="border-top: 1px solid; border-collapse: collapse; font-weight: bold;">

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -12,18 +12,18 @@
     <% ReportMailer::STATUS_ORDER.each do |status| %>
       <table style="border-bottom: 1px solid; border-collapse: collapse; max-width: 100%; text-align: center; margin-top: 3rem;">
         <caption style="text-align: left; margin-bottom: 1.5rem;">
-          <%= "#{Studio.statuses.key(status).capitalize}なスタジオは前週比で#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)}、ルームは#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)}の増減で、#{@studios.by_status(status).count}スタジオ、#{@rooms.by_status(status).count}ルームになりました。" %><br>
+          <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数は前週比で#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)}、ルーム数は#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)}の増減で、#{@studios.by_status(status).count}スタジオ、#{@rooms.by_status(status).count}ルームになりました。" %><br>
           <% if @studios.by_status(status).count > @studios.by_last_week_status(status).count %>
             <% if status == 1 %>
               <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました！！ありがとうございます！！(^^)" %>
             <% else %>
-              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました。対応をお願いします。" %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数が増えました。ご対応をお願いします。" %>
             <% end %>
           <% elsif @studios.by_status(status).count == @studios.by_last_week_status(status).count %>
             <% if status == 1 %>
-              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数は変わりません。来週は増えるといいなあとよもさんが言ってました。" %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数は変化なしです。来週は増えるといいなあとよもさんが言ってました。" %>
             <% else %>
-              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数は変わりません。" %>
+              <%= "#{Studio.statuses.key(status).capitalize}なスタジオ数は変化なしです。" %>
             <% end %>
           <% else %>
             <% if status == 1 %>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -16,35 +16,62 @@
             <th>都道府県</th>
             <th>エリア</th>
             <th>Studio</th>
-            <th>前週比増減</th>
             <th>Room</th>
-            <th>前週比増減</th>
           </tr>
           <tr style="border-bottom: 1px solid; border-collapse: collapse; font-weight: bold;">
             <td></td>
             <td></td>
-            <td><%= @studios.by_status(status).count %></td>
-            <td><%= @studios.by_status(status).count - @studios.by_last_week_status(status).count %></td>
-            <td><%= @rooms.by_status(status).count %></td>
-            <td><%= @rooms.by_status(status).count - @rooms.by_last_week_status(status).count %></td>
+            <td>
+              <% if @studios.by_status(status).count == @studios.by_last_week_status(status).count %>
+                <%= @studios.by_status(status).count %>
+              <% else %>
+                <%= @studios.by_status(status).count %><small><%= "(#{sprintf("%+d", @studios.by_status(status).count - @studios.by_last_week_status(status).count)})" %></small>
+              <% end %>
+            </td>
+            <td>
+              <% if @rooms.by_status(status).count == @rooms.by_last_week_status(status).count %>
+                <%= @rooms.by_status(status).count %>
+              <% else %>
+                <%= @rooms.by_status(status).count %><small><%= "(#{sprintf("%+d", @rooms.by_status(status).count - @rooms.by_last_week_status(status).count)})" %></small>
+              <% end %>
           </tr>
           <% @prefectures.each do |p| %>
             <tr style="border-top: 1px solid; border-collapse: collapse; font-weight: bold;">
               <td><%= p %></td>
               <td>合計</td>
-              <td><%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %></td>
-              <td><%= @area_studios.by_status(status).where(areas: {prefecture: p}).count - @area_studios.by_last_week_status(status).where(areas: {prefecture: p}).count %></td>
-              <td><%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count %></td>
-              <td><%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count - @area_studio_rooms.by_last_week_status(status).where(areas: {prefecture: p}).count %></td>
+              <td>
+                <% if @area_studios.by_status(status).where(areas: {prefecture: p}).count == @area_studios.by_last_week_status(status).where(areas: {prefecture: p}).count %>
+                  <%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %>
+                <% else %>
+                  <%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %><small><%= "(#{sprintf("%+d", @area_studios.by_status(status).where(areas: {prefecture: p}).count - @area_studios.by_last_week_status(status).where(areas: {prefecture: p}).count)})" %></small>
+                <% end %>
+              </td>
+              <td>
+                <% if @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count == @area_studio_rooms.by_last_week_status(status).where(areas: {prefecture: p}).count %>
+                  <%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count %>
+                <% else %>
+                  <%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count %><small><%= "(#{sprintf("%+d", @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count - @area_studio_rooms.by_last_week_status(status).where(areas: {prefecture: p}).count)})" %></small>
+                <% end %>
+              </td>
             </tr>
             <% Area.where(prefecture: p).each do |a| %>
               <tr>
                 <td></td>
                 <td><%= a.city %></td>
-                <td><%= @studios.by_status(status).where(area_id: a.id).count %></td>
-                <td><%= @studios.by_status(status).where(area_id: a.id).count - @studios.by_last_week_status(status).where(area_id: a.id).count %></td>
-                <td><%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count %></td>
-                <td><%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count - @studio_rooms.by_last_week_status(status).where(studios: {area_id: a.id}).count %></td>
+                <td>
+                  <% if @studios.by_status(status).where(area_id: a.id).count == @studios.by_last_week_status(status).where(area_id: a.id).count %>
+                    <%= @studios.by_status(status).where(area_id: a.id).count %>
+                  <% else %>
+                    <%= @studios.by_status(status).where(area_id: a.id).count %><small><%= "(#{sprintf("%+d", @studios.by_status(status).where(area_id: a.id).count - @studios.by_last_week_status(status).where(area_id: a.id).count)})" %></small>
+                  <% end %>
+                </td>
+                <td>
+                  <% if @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count == @studio_rooms.by_last_week_status(status).where(studios: {area_id: a.id}).count %>
+                    <%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count %>
+                  <% else %>
+                    <%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count %><small><%= "(#{sprintf("%+d", @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count - @studio_rooms.by_last_week_status(status).where(studios: {area_id: a.id}).count)})" %></small>
+                  <% end %>
+                </td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -13,27 +13,35 @@
             <th>都道府県</th>
             <th>エリア</th>
             <th>スタジオ数</th>
+            <th>前週比増減</th>
             <th>ルーム数</th>
+            <th>前週比増減</th>
           </tr>
           <tr style="border: 3px solid; border-collapse: collapse; font-weight: bold;">
             <td>合計</td>
             <td>-</td>
             <td><%= @studios.by_status(status).count %></td>
+            <td>(あとで追加)</td>
             <td><%= @rooms.by_status(status).count %></td>
+            <td>(あとで追加)</td>
           </tr>
           <% @prefectures.each do |p| %>
             <tr style="border: 1px solid; border-collapse: collapse; font-weight: bold;">
               <td><%= p %></td>
               <td>合計</td>
               <td><%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %></td>
+              <td>(あとで追加)</td>
               <td><%= @area_studio_rooms.by_status(status).where(areas: {prefecture: p}).count %></td>
+              <td>(あとで追加)</td>
             </tr>
             <% Area.where(prefecture: p).each do |a| %>
               <tr>
                 <td><%= p %></td>
                 <td><%= a.city %></td>
                 <td><%= @studios.by_status(status).where(area_id: a.id).count %></td>
+                <td>(あとで追加)</td>
                 <td><%= @studio_rooms.by_status(status).where(studios: {area_id: a.id}).count %></td>
+                <td>(あとで追加)</td>
               </tr>
             <% end %>
           <% end %>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -13,10 +13,10 @@
       <table style="border-bottom: 1px solid; border-collapse: collapse; max-width: 100%; text-align: center; margin-bottom: 1.5rem;">
         <caption style="font-size: 1.5rem; font-weight: bold;"><%= Studio.statuses.key(status) %></caption>
           <tr style="border-bottom: 1px solid; border-collapse: collapse;">
-            <th>都道府県</th>
-            <th>エリア</th>
-            <th>Studio</th>
-            <th>Room</th>
+            <th style="padding: 0 20px;">都道府県</th>
+            <th style="padding: 0 20px;">エリア</th>
+            <th style="padding: 0 20px;">Studio</th>
+            <th style="padding: 0 20px;">Room</th>
           </tr>
           <tr style="border-bottom: 1px solid; border-collapse: collapse; font-weight: bold;">
             <td></td>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -4,35 +4,32 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <h1>sagasu.space登録スタジオ数</h1>
-    <div style="border: 2px solid;">
-      <p><%= "・アクティブなスタジオ数は先週から#{@studios.by_status(1).count - @studios.by_last_week_status(1).count}個増えました。" %><br>
-      <%= "・停止中のスタジオ数は#{@studios.by_status(0).count}個です。" %><br>
-      <%= "・審査が必要なスタジオ数は#{@studios.by_status(2).count}個です。" %></p>
-      <p>※active...有効    inactive...停止中    reviewing...審査中</p>
+    <div>
+      <p><%= "・Activeなスタジオ数は#{@studios.by_status(1).count}です。先週から#{@studios.by_status(1).count - @studios.by_last_week_status(1).count}個増えました。" %><br>
+      <%= "・停止中(Inactive)のスタジオ数は#{@studios.by_status(0).count}個です。" %><br>
+      <%= "・審査(Reviewing)が必要なスタジオ数は#{@studios.by_status(2).count}個です。" %></p>
     </div>
-    <p>現在の登録スタジオ数をお知らせします。</p>
     <% ReportMailer::STATUS_ORDER.each do |status| %>
-      <table style="border: 3px solid; border-collapse: collapse; max-width: 100%; text-align: left; margin-bottom: 1.5rem;">
+      <table style="border-bottom: 1px solid; border-collapse: collapse; max-width: 100%; text-align: center; margin-bottom: 1.5rem;">
         <caption style="font-size: 1.5rem; font-weight: bold;"><%= Studio.statuses.key(status) %></caption>
-          <tr style="border: 3px solid; border-collapse: collapse;">
+          <tr style="border-bottom: 1px solid; border-collapse: collapse;">
             <th>都道府県</th>
             <th>エリア</th>
-            <th>スタジオ数</th>
+            <th>Studio</th>
             <th>前週比増減</th>
-            <th>ルーム数</th>
+            <th>Room</th>
             <th>前週比増減</th>
           </tr>
-          <tr style="border: 3px solid; border-collapse: collapse; font-weight: bold;">
-            <td>合計</td>
-            <td>-</td>
+          <tr style="border-bottom: 1px solid; border-collapse: collapse; font-weight: bold;">
+            <td></td>
+            <td></td>
             <td><%= @studios.by_status(status).count %></td>
             <td><%= @studios.by_status(status).count - @studios.by_last_week_status(status).count %></td>
             <td><%= @rooms.by_status(status).count %></td>
             <td><%= @rooms.by_status(status).count - @rooms.by_last_week_status(status).count %></td>
           </tr>
           <% @prefectures.each do |p| %>
-            <tr style="border: 1px solid; border-collapse: collapse; font-weight: bold;">
+            <tr style="border-top: 1px solid; border-collapse: collapse; font-weight: bold;">
               <td><%= p %></td>
               <td>合計</td>
               <td><%= @area_studios.by_status(status).where(areas: {prefecture: p}).count %></td>
@@ -42,7 +39,7 @@
             </tr>
             <% Area.where(prefecture: p).each do |a| %>
               <tr>
-                <td><%= p %></td>
+                <td></td>
                 <td><%= a.city %></td>
                 <td><%= @studios.by_status(status).where(area_id: a.id).count %></td>
                 <td><%= @studios.by_status(status).where(area_id: a.id).count - @studios.by_last_week_status(status).where(area_id: a.id).count %></td>
@@ -53,6 +50,7 @@
           <% end %>
       </table>
     <% end %>
+    <p>※増減は前週比の数値です。</p>
 
     <p>今週もお疲れ様でした！</p>
   </body>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div style="margin-bottom: 3rem;">
-      <p><%= "・Activeなスタジオ数は#{@studios.by_status(1).count}です。先週からの増減は#{@studios.by_status(1).count - @studios.by_last_week_status(1).count}です。" %><br>
+    <p><%= "・Activeなスタジオ数は#{@studios.by_status(1).count}です。先週からの増減は" %><%= @studios.by_status(1).count == @studios.by_last_week_status(1).count ? "ありません。" : "#{sprintf("%+d", @studios.by_status(1).count - @studios.by_last_week_status(1).count)}です。" %><br>
       <%= "・停止中(Inactive)のスタジオ数は#{@studios.by_status(0).count}個です。" %><br>
       <%= "・審査(Reviewing)が必要なスタジオ数は#{@studios.by_status(2).count}個です。" %></p>
     </div>

--- a/app/views/report_mailer/send_studios_report.html.erb
+++ b/app/views/report_mailer/send_studios_report.html.erb
@@ -9,6 +9,7 @@
       <p><%= "・アクティブなスタジオ数は先週から#{@studios.by_status(1).count - @studios.by_last_week_status(1).count}個増えました。" %><br>
       <%= "・停止中のスタジオ数は#{@studios.by_status(0).count}個です。" %><br>
       <%= "・審査が必要なスタジオ数は#{@studios.by_status(2).count}個です。" %></p>
+      <p>※active...有効    inactive...停止中    reviewing...審査中</p>
     </div>
     <p>現在の登録スタジオ数をお知らせします。</p>
     <% ReportMailer::STATUS_ORDER.each do |status| %>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,10 +4,12 @@ set :output, 'log/cron.log'
 # production環境のジョブ指定
 if @environment.to_sym == :production
   # 火曜日のpm9時にスケジューリング
+  # スタジオ数/ルーム数の社内メール通知
   every :tuesday, at: '9:00 pm' do
     rake "send_email:number_of_studios"
   end
   # 火曜日のpm9時1分にスケジューリング
+  # studios/roomsテーブルのlast_week_statusカラムをUPDATE
   every :tuesday, at: '9:01 pm' do
     rake "update_last_week_status:studios"
     rake "update_last_week_status:rooms"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,10 +8,4 @@ if @environment.to_sym == :production
   every :tuesday, at: '9:00 pm' do
     rake "send_email:number_of_studios"
   end
-  # 火曜日のpm9時1分にスケジューリング
-  # studios/roomsテーブルのlast_week_statusカラムをUPDATE
-  every :tuesday, at: '9:01 pm' do
-    rake "update_last_week_status:studios"
-    rake "update_last_week_status:rooms"
-  end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,4 +7,9 @@ if @environment.to_sym == :production
   every :tuesday, at: '9:00 pm' do
     rake "send_email:number_of_studios"
   end
+  # 火曜日のpm9時1分にスケジューリング
+  every :tuesday, at: '9:01 pm' do
+    rake "update_last_week_status:studios"
+    rake "update_last_week_status:rooms"
+  end
 end

--- a/db/migrate/20190529091515_add_last_week_status_to_studios_and_rooms.rb
+++ b/db/migrate/20190529091515_add_last_week_status_to_studios_and_rooms.rb
@@ -1,0 +1,6 @@
+class AddLastWeekStatusToStudiosAndRooms < ActiveRecord::Migration[5.0]
+  def change
+    add_column :studios, :last_week_status, :integer, default: 0, limit: 1, after: :status
+    add_column :rooms,   :last_week_status, :integer, default: 0, limit: 1, after: :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190122123522) do
+ActiveRecord::Schema.define(version: 20190529091515) do
 
   create_table "areas", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "prefecture"
@@ -33,25 +33,26 @@ ActiveRecord::Schema.define(version: 20190122123522) do
     t.integer  "studio_id"
     t.string   "name"
     t.integer  "size"
-    t.integer  "capacity",                   default: 0,     null: false
-    t.integer  "price",                      default: 0,     null: false
+    t.integer  "capacity",                       default: 0,     null: false
+    t.integer  "price",                          default: 0,     null: false
     t.string   "mirror"
     t.integer  "floor"
-    t.boolean  "speaker",                    default: false, null: false
-    t.boolean  "mixer",                      default: false, null: false
-    t.boolean  "cd",                         default: false, null: false
-    t.boolean  "md",                         default: false, null: false
-    t.boolean  "mp3",                        default: false, null: false
+    t.boolean  "speaker",                        default: false, null: false
+    t.boolean  "mixer",                          default: false, null: false
+    t.boolean  "cd",                             default: false, null: false
+    t.boolean  "md",                             default: false, null: false
+    t.boolean  "mp3",                            default: false, null: false
     t.string   "other_source"
-    t.boolean  "dimmable",                   default: false, null: false
-    t.boolean  "wifi",                       default: false, null: false
+    t.boolean  "dimmable",                       default: false, null: false
+    t.boolean  "wifi",                           default: false, null: false
     t.string   "image"
-    t.text     "feature",      limit: 65535
-    t.text     "remarks",      limit: 65535
-    t.text     "memo",         limit: 65535
-    t.integer  "status",       limit: 1,     default: 0
-    t.datetime "created_at",                                 null: false
-    t.datetime "updated_at",                                 null: false
+    t.text     "feature",          limit: 65535
+    t.text     "remarks",          limit: 65535
+    t.text     "memo",             limit: 65535
+    t.integer  "status",           limit: 1,     default: 0
+    t.integer  "last_week_status", limit: 1,     default: 0
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
   end
 
   create_table "studio_images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -81,6 +82,7 @@ ActiveRecord::Schema.define(version: 20190122123522) do
     t.text     "remarks",            limit: 65535
     t.text     "memo",               limit: 65535
     t.integer  "status",             limit: 1,     default: 0
+    t.integer  "last_week_status",   limit: 1,     default: 0
     t.string   "slug"
     t.string   "meta_title"
     t.string   "meta_description"

--- a/lib/tasks/send_email.rake
+++ b/lib/tasks/send_email.rake
@@ -2,5 +2,7 @@ namespace :send_email do
   desc "Send the number of studios via email"
   task number_of_studios: :environment do
     ReportMailer.send_studios_report.deliver
+    Studio.update_all("last_week_status = status")
+    Room.update_all("last_week_status = status")
   end
 end

--- a/lib/tasks/update_last_week_status.rake
+++ b/lib/tasks/update_last_week_status.rake
@@ -1,0 +1,9 @@
+namespace :update_last_week_status do
+  desc "Update last_week_status of studios and rooms table"
+  task studios: :environment do
+    Studio.update_all("last_week_status = status")
+  end
+  task rooms: :environment do
+    Room.update_all("last_week_status = status")
+  end
+end

--- a/lib/tasks/update_last_week_status.rake
+++ b/lib/tasks/update_last_week_status.rake
@@ -1,9 +1,0 @@
-namespace :update_last_week_status do
-  desc "Update last_week_status of studios and rooms table"
-  task studios: :environment do
-    Studio.update_all("last_week_status = status")
-  end
-  task rooms: :environment do
-    Room.update_all("last_week_status = status")
-  end
-end


### PR DESCRIPTION
# 関連issue
https://github.com/Vintom/studio-sagasu/issues/77

# 要件
* 前週比スタジオ数/ルーム数増減を表に追加する
* ビューの上部に概況欄をつくる
    * 各ステータスのスタジオ数のハイライトを概況欄に表示する
    * 各ステータスの説明を概況欄に表示する

# 作業工程
* [x] 要件定義
* [x] 前週比スタジオ数/ルーム数増減を表に追加する
    * [x] 表に前週比増減欄追加
    * [x] studios/roomsテーブルに、メール送信直後のステータスを入れるカラム追加(last_week_status)
    * [x] studios/roomsモデルに、by_last_week_statusスコープを追加
              ※enum last_week_statusはあっても良いが、当座は使わないのでいったん不要？
    * [x] 表に前週比増減を出力する
    * [x] メール送信直後にカラムにレコードを入れるscript書く
    * [x] 定期的にscript実行するバッチ処理作成
* [x] ビューの上部に概況欄をつくる
    * [x] 各ステータスのスタジオ数のハイライトを概況欄に表示する
    * [x] 各ステータスの説明を概況欄に表示する
* [ ] リファクタリング
* [x] style調整